### PR TITLE
Fix #5: Typo in description of maven-deploy workflow

### DIFF
--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -12,7 +12,7 @@ on:
         required: true
       release_type:
         type: string
-        description: choice of release type -- snapshot / release
+        description: choice of release type (snapshot / release)
         default: snapshot
 
 jobs:

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -12,7 +12,7 @@ on:
         required: true
       release_type:
         type: string
-        description: chose of deployment snapshot or release snapshot or release
+        description: choice of release type -- snapshot / release
         default: snapshot
 
 jobs:


### PR DESCRIPTION
I fixed the typo and made the description a bit more clear - there are only two options: `snapshot` or `release`.