### PR TITLE
Fix coverity-scan

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,4 +1,3 @@
-
 on:
   workflow_call:
     inputs:
@@ -22,10 +21,6 @@ on:
         type: string
         description: directory with pom.xml to be executed
         default: .
-      java_version:
-        type: string
-        description: set version of java used to run the maven
-        default: '17'
 
 jobs:
   build:


### PR DESCRIPTION
Because of duplicated java_version, returned error: Invalid type for `on`